### PR TITLE
Add Tkinter GUI for tween GIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ The pipeline now supports remote video generation APIs, making high-quality vide
 
 See the "Configuration" section for details on setting up different backends.
 
+### Generating GIFs with DALL·E-3 Tweening
+
+You can create short animations between three keyframes using the included
+`dalle_tween_gui.py` tool. An OpenAI API key is required.
+
+```bash
+python dalle_tween_gui.py
+```
+
+Select your start, middle and end images, choose how many tween frames to
+generate between each pair, and press **Generate**. The frames and resulting
+`tween.gif` will be saved to `./tween_output/`.
+
 ## System Architecture
 
 ### 1. Segment Planning with OpenAI

--- a/dalle_tween.py
+++ b/dalle_tween.py
@@ -1,0 +1,165 @@
+"""Utilities for generating DALL·E tween frames"""
+
+import base64
+import logging
+import os
+import time
+from typing import List
+
+from PIL import Image
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+
+def generate_dalle_prompts(start_image: str, end_image: str, frame_count: int, api_key: str) -> List[str]:
+    """Generate DALL·E prompts for in-between frames.
+
+    Args:
+        start_image: Path to the starting keyframe image file.
+        end_image: Path to the ending keyframe image file.
+        frame_count: Number of intermediate frames to describe.
+        api_key: OpenAI API key.
+
+    Returns:
+        A list of text prompts for each tween frame.
+
+    Raises:
+        Exception: Propagates any errors from the OpenAI API call.
+    """
+    logger.info(
+        "Generating %s DALL·E prompts between %s and %s",
+        frame_count,
+        start_image,
+        end_image,
+    )
+
+    with open(start_image, "rb") as f:
+        start_b64 = base64.b64encode(f.read()).decode()
+
+    with open(end_image, "rb") as f:
+        end_b64 = base64.b64encode(f.read()).decode()
+
+    client = OpenAI(api_key=api_key)
+
+    system_message = (
+        "You generate concise DALL·E prompts describing a smooth visual "
+        "transition between two images. Number the prompts starting at 1 "
+        "and do not include additional commentary."
+    )
+    user_content = [
+        {
+            "type": "text",
+            "text": (
+                f"Create {frame_count} intermediate image descriptions for DALL·E 3 "
+                "that morph the first image into the second. Reply with one "
+                "numbered prompt per line."
+            ),
+        },
+        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{start_b64}"}},
+        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{end_b64}"}},
+    ]
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_content},
+            ],
+            temperature=0.7,
+            max_tokens=frame_count * 50,
+        )
+    except Exception as exc:
+        logger.error("OpenAI request failed: %s", exc)
+        raise
+
+    text = response.choices[0].message.content.strip()
+    prompts = [line.split(".", 1)[-1].strip() for line in text.splitlines() if line.strip()]
+    prompts = [p for p in prompts if p]
+
+    if len(prompts) != frame_count:
+        logger.warning(
+            "Expected %s prompts but received %s", frame_count, len(prompts)
+        )
+
+    return prompts
+
+
+def generate_dalle_images(prompts: List[str], output_dir: str, api_key: str, max_retries: int = 2) -> List[str]:
+    """Generate images from prompts using DALL·E 3.
+
+    Args:
+        prompts: List of text prompts to render.
+        output_dir: Directory where generated frames will be saved.
+        api_key: OpenAI API key.
+        max_retries: Number of retries for each API call on failure.
+
+    Returns:
+        Paths to the saved image files in order.
+
+    Raises:
+        Exception: Propagates any errors after exhausting retries.
+    """
+    client = OpenAI(api_key=api_key)
+    os.makedirs(output_dir, exist_ok=True)
+    saved_paths: List[str] = []
+
+    for idx, prompt in enumerate(prompts):
+        frame_path = os.path.join(output_dir, f"frame_{idx:03d}.png")
+        logger.info("Generating frame %s with DALL·E 3", idx)
+
+        for retry in range(max_retries + 1):
+            try:
+                response = client.images.generate(
+                    model="dall-e-3",
+                    prompt=prompt,
+                    n=1,
+                    size="1024x1024",
+                )
+                break
+            except Exception as exc:
+                logger.error("Error generating frame %s (attempt %s/%s): %s", idx, retry + 1, max_retries, exc)
+                if retry == max_retries:
+                    raise
+                time.sleep(2)
+
+        image_base64 = response.data[0].b64_json
+        with open(frame_path, "wb") as img_file:
+            img_file.write(base64.b64decode(image_base64))
+
+        saved_paths.append(os.path.abspath(frame_path))
+
+    return saved_paths
+
+
+def combine_images_to_gif(image_paths: List[str], gif_path: str, duration: float = 0.2) -> str:
+    """Combine a list of images into an animated GIF.
+
+    Args:
+        image_paths: Ordered list of image file paths to include in the GIF.
+        gif_path: Path where the resulting GIF should be saved.
+        duration: Delay between frames in seconds.
+
+    Returns:
+        Path to the created GIF.
+    """
+    logger.info("Creating GIF %s from %s images", gif_path, len(image_paths))
+
+    if not image_paths:
+        raise ValueError("image_paths must contain at least one frame")
+
+    frames = [Image.open(p) for p in image_paths]
+    os.makedirs(os.path.dirname(gif_path), exist_ok=True)
+
+    first_frame, *rest = frames
+    first_frame.save(
+        gif_path,
+        save_all=True,
+        append_images=rest,
+        duration=int(duration * 1000),
+        loop=0,
+    )
+
+    logger.info("Saved animated GIF to %s", gif_path)
+    return os.path.abspath(gif_path)

--- a/dalle_tween_gui.py
+++ b/dalle_tween_gui.py
@@ -1,0 +1,123 @@
+"""Simple GUI for generating tweened GIFs using DALL·E 3.
+
+Run with:
+    python dalle_tween_gui.py
+
+The application lets you select start, middle, and end keyframes and a frame
+count. It generates DALL·E 3 prompts and images for each transition and combines
+the results into an animated GIF.
+"""
+
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+from typing import List
+
+from pipeline import Colors
+from dalle_tween import (
+    generate_dalle_prompts,
+    generate_dalle_images,
+    combine_images_to_gif,
+)
+
+
+class TweenApp:
+    """Tkinter application for creating GIFs from keyframes."""
+
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        master.title("DALL·E Tween GIF Generator")
+
+        self.api_key_var = tk.StringVar()
+        self.start_path = tk.StringVar()
+        self.middle_path = tk.StringVar()
+        self.end_path = tk.StringVar()
+        self.count_var = tk.IntVar(value=2)
+
+        tk.Label(master, text="OpenAI API Key:").grid(row=0, column=0, sticky="e")
+        tk.Entry(master, textvariable=self.api_key_var, width=40, show="*").grid(row=0, column=1, sticky="w")
+
+        tk.Button(master, text="Start Image", command=self.pick_start).grid(row=1, column=0, sticky="e")
+        tk.Label(master, textvariable=self.start_path, width=40, anchor="w").grid(row=1, column=1, sticky="w")
+
+        tk.Button(master, text="Middle Image", command=self.pick_middle).grid(row=2, column=0, sticky="e")
+        tk.Label(master, textvariable=self.middle_path, width=40, anchor="w").grid(row=2, column=1, sticky="w")
+
+        tk.Button(master, text="End Image", command=self.pick_end).grid(row=3, column=0, sticky="e")
+        tk.Label(master, textvariable=self.end_path, width=40, anchor="w").grid(row=3, column=1, sticky="w")
+
+        tk.Label(master, text="Tweens per transition:").grid(row=4, column=0, sticky="e")
+        tk.Spinbox(master, from_=1, to=10, textvariable=self.count_var, width=5).grid(row=4, column=1, sticky="w")
+
+        tk.Button(master, text="Generate", command=self.generate).grid(row=5, column=0, columnspan=2)
+
+        self.log = scrolledtext.ScrolledText(master, width=60, height=15)
+        self.log.grid(row=6, column=0, columnspan=2, pady=10)
+
+    # ------------------------------------------------------------------
+    # File selection helpers
+    # ------------------------------------------------------------------
+    def pick_start(self) -> None:
+        path = filedialog.askopenfilename(title="Select start keyframe")
+        if path:
+            self.start_path.set(path)
+
+    def pick_middle(self) -> None:
+        path = filedialog.askopenfilename(title="Select middle keyframe")
+        if path:
+            self.middle_path.set(path)
+
+    def pick_end(self) -> None:
+        path = filedialog.askopenfilename(title="Select end keyframe")
+        if path:
+            self.end_path.set(path)
+
+    # ------------------------------------------------------------------
+    def log_message(self, message: str, color: str = Colors.BLUE) -> None:
+        """Print and display a message."""
+        print(color + message + Colors.RESET)
+        self.log.insert(tk.END, message + "\n")
+        self.log.see(tk.END)
+
+    def generate(self) -> None:
+        api_key = self.api_key_var.get().strip()
+        start = self.start_path.get()
+        middle = self.middle_path.get()
+        end = self.end_path.get()
+        count = self.count_var.get()
+
+        if not api_key or not start or not middle or not end:
+            messagebox.showerror("Missing Information", "Please select all images and provide the API key.")
+            return
+
+        out_dir = os.path.join(os.getcwd(), "tween_output")
+        frames_dir = os.path.join(out_dir, "frames")
+        os.makedirs(frames_dir, exist_ok=True)
+
+        all_images: List[str] = []
+
+        try:
+            self.log_message("Generating prompts for start->middle...")
+            prompts = generate_dalle_prompts(start, middle, count, api_key)
+            self.log_message(f"Generated {len(prompts)} prompts")
+            images = generate_dalle_images(prompts, frames_dir, api_key)
+            all_images.extend(images)
+
+            self.log_message("Generating prompts for middle->end...")
+            prompts = generate_dalle_prompts(middle, end, count, api_key)
+            self.log_message(f"Generated {len(prompts)} prompts")
+            images = generate_dalle_images(prompts, frames_dir, api_key)
+            all_images.extend(images)
+
+            gif_path = os.path.join(out_dir, "tween.gif")
+            combine_images_to_gif(all_images, gif_path)
+            self.log_message(f"GIF saved to {gif_path}", color=Colors.GREEN)
+        except Exception as exc:
+            self.log_message(f"Error: {exc}", color=Colors.RED)
+            messagebox.showerror("Generation Failed", str(exc))
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = TweenApp(root)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- build `dalle_tween_gui.py` for local tween generation
- describe how to run the GUI in README

## Testing
- `pytest -q`
- `python -m py_compile dalle_tween_gui.py`
- `python -m py_compile dalle_tween.py`


------
https://chatgpt.com/codex/tasks/task_b_68692f8f07e48326b8ceab07eb985da6