### PR TITLE
Fix GIF tween generation to preserve keyframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ python dalle_tween_gui.py
 ```
 
 Select your start, middle and end images, choose how many tween frames to
-generate between each pair, and press **Generate**. All frames are saved in
-`./tween_output/frames/` and the final animation will be written to
-`./tween_output/tween.gif`.
+generate between each pair, and press **Generate**. The selected keyframes are
+copied into the frames directory and inserted unchanged at the beginning,
+middle and end of the animation. DALL·E only creates the in-between frames.
+Each tween prompt instructs the model to match the artistic style and key
+visual elements of the surrounding keyframes for smooth continuity. All frames
+are saved in `./tween_output/frames/` and the final animation will be written
+to `./tween_output/tween.gif`.
+
+For advanced use, `generate_dalle_images` now accepts a `start_index` parameter
+to control the numbering of output frames when generating multiple tween
+segments. This prevents files from being overwritten.
 
 ## System Architecture
 

--- a/dalle_tween.py
+++ b/dalle_tween.py
@@ -47,8 +47,10 @@ def generate_dalle_prompts(start_image: str, end_image: str, frame_count: int, a
 
     system_message = (
         "You generate concise DALL·E prompts describing a smooth visual "
-        "transition between two images. Number the prompts starting at 1 "
-        "and do not include additional commentary."
+        "transition between two images. Maintain the artistic style, color "
+        "palette and key visual elements from the start and end frames to "
+        "ensure continuity. Number the prompts starting at 1 and do not "
+        "include additional commentary."
     )
     user_content = [
         {
@@ -89,13 +91,20 @@ def generate_dalle_prompts(start_image: str, end_image: str, frame_count: int, a
     return prompts
 
 
-def generate_dalle_images(prompts: List[str], output_dir: str, api_key: str, max_retries: int = 2) -> List[str]:
+def generate_dalle_images(
+    prompts: List[str],
+    output_dir: str,
+    api_key: str,
+    start_index: int = 0,
+    max_retries: int = 2,
+) -> List[str]:
     """Generate images from prompts using DALL·E 3.
 
     Args:
         prompts: List of text prompts to render.
         output_dir: Directory where generated frames will be saved.
         api_key: OpenAI API key.
+        start_index: Starting index for output file numbering.
         max_retries: Number of retries for each API call on failure.
 
     Returns:
@@ -108,7 +117,7 @@ def generate_dalle_images(prompts: List[str], output_dir: str, api_key: str, max
     os.makedirs(output_dir, exist_ok=True)
     saved_paths: List[str] = []
 
-    for idx, prompt in enumerate(prompts):
+    for idx, prompt in enumerate(prompts, start=start_index):
         frame_path = os.path.join(output_dir, f"frame_{idx:03d}.png")
         logger.info("Generating frame %s with DALL·E 3", idx)
 

--- a/dalle_tween_gui.py
+++ b/dalle_tween_gui.py
@@ -9,6 +9,7 @@ the results into an animated GIF.
 """
 
 import os
+import shutil
 import logging
 
 import tkinter as tk
@@ -115,19 +116,37 @@ class TweenApp:
         os.makedirs(frames_dir, exist_ok=True)
 
         all_images: List[str] = []
+        frame_idx = 0
+
+        # Copy keyframes into the frames directory
+        start_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
+        shutil.copy(start, start_frame)
+        all_images.append(start_frame)
+        frame_idx += 1
 
         try:
             self.log_message("Generating prompts for start->middle...")
             prompts = generate_dalle_prompts(start, middle, count, api_key)
             self.log_message(f"Generated {len(prompts)} prompts")
-            images = generate_dalle_images(prompts, frames_dir, api_key)
+            images = generate_dalle_images(prompts, frames_dir, api_key, start_index=frame_idx)
             all_images.extend(images)
+            frame_idx += len(images)
+
+            middle_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
+            shutil.copy(middle, middle_frame)
+            all_images.append(middle_frame)
+            frame_idx += 1
 
             self.log_message("Generating prompts for middle->end...")
             prompts = generate_dalle_prompts(middle, end, count, api_key)
             self.log_message(f"Generated {len(prompts)} prompts")
-            images = generate_dalle_images(prompts, frames_dir, api_key)
+            images = generate_dalle_images(prompts, frames_dir, api_key, start_index=frame_idx)
             all_images.extend(images)
+            frame_idx += len(images)
+
+            end_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
+            shutil.copy(end, end_frame)
+            all_images.append(end_frame)
 
             gif_path = os.path.join(out_dir, "tween.gif")
             combine_images_to_gif(all_images, gif_path)


### PR DESCRIPTION
## Summary
- keep the user-provided start/middle/end frames when creating the GIF
- ensure generated tween frames follow sequential numbering using `start_index`
- instruct DALL·E prompt generation to match the keyframe style
- document the updated behaviour and new `start_index` parameter
- clarify in the docs that keyframes are copied directly and only the tween frames are generated

## Testing
- `python -m py_compile dalle_tween.py dalle_tween_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_686940b7bb5883269a022294ac0032c3