### PR TITLE
Add FLF2V tween video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,27 +35,22 @@ The pipeline now supports remote video generation APIs, making high-quality vide
 
 See the "Configuration" section for details on setting up different backends.
 
-### Generating GIFs with DALL·E-3 Tweening
+### Generating Tween Videos with FLF2V
 
-You can create short animations between three keyframes using the included
-`dalle_tween_gui.py` tool. An OpenAI API key is required.
+The `dalle_tween_gui.py` tool can now produce a smooth tween video using the
+Wan2.1 FLF2V model.
 
 ```bash
 python dalle_tween_gui.py
 ```
 
-Select your start, middle and end images, choose how many tween frames to
-generate between each pair, and press **Generate**. The selected keyframes are
-copied into the frames directory and inserted unchanged at the beginning,
-middle and end of the animation. DALL·E only creates the in-between frames.
-Each tween prompt instructs the model to match the artistic style and key
-visual elements of the surrounding keyframes for smooth continuity. All frames
-are saved in `./tween_output/frames/` and the final animation will be written
-to `./tween_output/tween.gif`.
+Select your start, middle and end keyframes and press **Generate**. The
+application calls the FLF2V model twice: once between the first and middle
+frames and again between the middle and last frames. The two 1‑second clips are
+stitched together into `./tween_output/tween.mp4`.
 
-For advanced use, `generate_dalle_images` now accepts a `start_index` parameter
-to control the numbering of output frames when generating multiple tween
-segments. This prevents files from being overwritten.
+Set the `WAN2_DIR` and `FLF2V_MODEL_DIR` environment variables to point to your
+local Wan2.1 installation and model weights before running the tool.
 
 ## System Architecture
 

--- a/dalle_tween.py
+++ b/dalle_tween.py
@@ -11,6 +11,7 @@ from keyframe_generator import reword_prompt_for_safety
 
 from PIL import Image
 from openai import OpenAI
+from pipeline import run_command, stitch_video_segments
 
 logger = logging.getLogger(__name__)
 
@@ -189,3 +190,50 @@ def combine_images_to_gif(image_paths: List[str], gif_path: str, duration: float
 
     logger.info("Saved animated GIF to %s", gif_path)
     return os.path.abspath(gif_path)
+
+
+def generate_flf2v_tween(
+    start_frame: str,
+    end_frame: str,
+    output_path: str,
+    wan2_dir: str,
+    flf2v_model_dir: str,
+    frame_num: int = 16,
+) -> str:
+    """Generate a short video tween between two keyframes using Wan2.1 FLF2V."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    base_cmd = [
+        "--task",
+        "flf2v-14B",
+        "--size",
+        "1280*720",
+        "--ckpt_dir",
+        flf2v_model_dir,
+        "--first_frame",
+        start_frame,
+        "--last_frame",
+        end_frame,
+        "--frame_num",
+        str(frame_num),
+        "--prompt",
+        "smooth transition",
+        "--save_file",
+        output_path,
+        "--sample_guide_scale",
+        "5.0",
+        "--sample_steps",
+        "40",
+        "--sample_shift",
+        "5.0",
+    ]
+
+    cmd = ["python", "generate.py"] + base_cmd
+    run_command(cmd, cwd=wan2_dir)
+    return os.path.abspath(output_path)
+
+
+def combine_videos(video_paths: List[str], out_file: str) -> str:
+    """Concatenate video files into a single output."""
+    os.makedirs(os.path.dirname(out_file), exist_ok=True)
+    return stitch_video_segments(video_paths, out_file) or out_file

--- a/dalle_tween_gui.py
+++ b/dalle_tween_gui.py
@@ -1,11 +1,11 @@
-"""Simple GUI for generating tweened GIFs using DALL·E 3.
+"""Simple GUI for tweening between three keyframes.
 
 Run with:
     python dalle_tween_gui.py
 
-The application lets you select start, middle, and end keyframes and a frame
-count. It generates DALL·E 3 prompts and images for each transition and combines
-the results into an animated GIF.
+Select start, middle and end images and the app will invoke the Wan2.1 FLF2V
+model to generate short video transitions between them. The two videos are
+stitched into a single MP4 saved in ``./tween_output``.
 """
 
 import os
@@ -34,41 +34,36 @@ logger = logging.getLogger(__name__)
 
 
 from dalle_tween import (
-    generate_dalle_prompts,
-    generate_dalle_images,
-    combine_images_to_gif,
+    generate_flf2v_tween,
+    combine_videos,
 )
 
 
 class TweenApp:
-    """Tkinter application for creating GIFs from keyframes."""
+    """Tkinter application for creating short tween videos."""
 
     def __init__(self, master: tk.Tk) -> None:
         self.master = master
-        master.title("DALL·E Tween GIF Generator")
+        master.title("FLF2V Tween Video Generator")
 
-        self.api_key_var = tk.StringVar()
         self.start_path = tk.StringVar()
         self.middle_path = tk.StringVar()
         self.end_path = tk.StringVar()
         self.count_var = tk.IntVar(value=2)
 
-        tk.Label(master, text="OpenAI API Key:").grid(row=0, column=0, sticky="e")
-        tk.Entry(master, textvariable=self.api_key_var, width=40, show="*").grid(row=0, column=1, sticky="w")
+        tk.Button(master, text="Start Image", command=self.pick_start).grid(row=0, column=0, sticky="e")
+        tk.Label(master, textvariable=self.start_path, width=40, anchor="w").grid(row=0, column=1, sticky="w")
 
-        tk.Button(master, text="Start Image", command=self.pick_start).grid(row=1, column=0, sticky="e")
-        tk.Label(master, textvariable=self.start_path, width=40, anchor="w").grid(row=1, column=1, sticky="w")
+        tk.Button(master, text="Middle Image", command=self.pick_middle).grid(row=1, column=0, sticky="e")
+        tk.Label(master, textvariable=self.middle_path, width=40, anchor="w").grid(row=1, column=1, sticky="w")
 
-        tk.Button(master, text="Middle Image", command=self.pick_middle).grid(row=2, column=0, sticky="e")
-        tk.Label(master, textvariable=self.middle_path, width=40, anchor="w").grid(row=2, column=1, sticky="w")
+        tk.Button(master, text="End Image", command=self.pick_end).grid(row=2, column=0, sticky="e")
+        tk.Label(master, textvariable=self.end_path, width=40, anchor="w").grid(row=2, column=1, sticky="w")
 
-        tk.Button(master, text="End Image", command=self.pick_end).grid(row=3, column=0, sticky="e")
-        tk.Label(master, textvariable=self.end_path, width=40, anchor="w").grid(row=3, column=1, sticky="w")
+        tk.Label(master, text="Tweens per transition:").grid(row=3, column=0, sticky="e")
+        tk.Spinbox(master, from_=1, to=10, textvariable=self.count_var, width=5).grid(row=3, column=1, sticky="w")
 
-        tk.Label(master, text="Tweens per transition:").grid(row=4, column=0, sticky="e")
-        tk.Spinbox(master, from_=1, to=10, textvariable=self.count_var, width=5).grid(row=4, column=1, sticky="w")
-
-        tk.Button(master, text="Generate", command=self.generate).grid(row=5, column=0, columnspan=2)
+        tk.Button(master, text="Generate", command=self.generate).grid(row=4, column=0, columnspan=2)
 
         self.log = scrolledtext.ScrolledText(master, width=60, height=15)
         self.log.grid(row=6, column=0, columnspan=2, pady=10)
@@ -101,56 +96,50 @@ class TweenApp:
         self.log.see(tk.END)
 
     def generate(self) -> None:
-        api_key = self.api_key_var.get().strip()
         start = self.start_path.get()
         middle = self.middle_path.get()
         end = self.end_path.get()
-        count = self.count_var.get()
+        _ = self.count_var.get()
 
-        if not api_key or not start or not middle or not end:
-            messagebox.showerror("Missing Information", "Please select all images and provide the API key.")
+        if not start or not middle or not end:
+            messagebox.showerror("Missing Information", "Please select all images.")
+            return
+
+        wan2_dir = os.getenv("WAN2_DIR")
+        flf2v_model_dir = os.getenv("FLF2V_MODEL_DIR")
+        if not wan2_dir or not flf2v_model_dir:
+            messagebox.showerror(
+                "Configuration Missing",
+                "WAN2_DIR and FLF2V_MODEL_DIR environment variables must be set.",
+            )
             return
 
         out_dir = os.path.join(os.getcwd(), "tween_output")
         frames_dir = os.path.join(out_dir, "frames")
+        videos_dir = os.path.join(out_dir, "videos")
         os.makedirs(frames_dir, exist_ok=True)
+        os.makedirs(videos_dir, exist_ok=True)
 
-        all_images: List[str] = []
-        frame_idx = 0
+        start_frame = os.path.join(frames_dir, "start.png")
+        middle_frame = os.path.join(frames_dir, "middle.png")
+        end_frame = os.path.join(frames_dir, "end.png")
 
-        # Copy keyframes into the frames directory
-        start_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
         shutil.copy(start, start_frame)
-        all_images.append(start_frame)
-        frame_idx += 1
+        shutil.copy(middle, middle_frame)
+        shutil.copy(end, end_frame)
 
         try:
-            self.log_message("Generating prompts for start->middle...")
-            prompts = generate_dalle_prompts(start, middle, count, api_key)
-            self.log_message(f"Generated {len(prompts)} prompts")
-            images = generate_dalle_images(prompts, frames_dir, api_key, start_index=frame_idx)
-            all_images.extend(images)
-            frame_idx += len(images)
+            self.log_message("Generating video start->middle...")
+            tween1 = os.path.join(videos_dir, "tween_01.mp4")
+            generate_flf2v_tween(start_frame, middle_frame, tween1, wan2_dir, flf2v_model_dir)
 
-            middle_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
-            shutil.copy(middle, middle_frame)
-            all_images.append(middle_frame)
-            frame_idx += 1
+            self.log_message("Generating video middle->end...")
+            tween2 = os.path.join(videos_dir, "tween_02.mp4")
+            generate_flf2v_tween(middle_frame, end_frame, tween2, wan2_dir, flf2v_model_dir)
 
-            self.log_message("Generating prompts for middle->end...")
-            prompts = generate_dalle_prompts(middle, end, count, api_key)
-            self.log_message(f"Generated {len(prompts)} prompts")
-            images = generate_dalle_images(prompts, frames_dir, api_key, start_index=frame_idx)
-            all_images.extend(images)
-            frame_idx += len(images)
-
-            end_frame = os.path.join(frames_dir, f"frame_{frame_idx:03d}.png")
-            shutil.copy(end, end_frame)
-            all_images.append(end_frame)
-
-            gif_path = os.path.join(out_dir, "tween.gif")
-            combine_images_to_gif(all_images, gif_path)
-            self.log_message(f"GIF saved to {gif_path}", color=Colors.GREEN)
+            final_video = os.path.join(out_dir, "tween.mp4")
+            combine_videos([tween1, tween2], final_video)
+            self.log_message(f"Video saved to {final_video}", color=Colors.GREEN)
         except Exception as exc:
             self.log_message(f"Error: {exc}", color=Colors.RED)
             messagebox.showerror("Generation Failed", str(exc))


### PR DESCRIPTION
## Summary
- add FLF2V tween and combine helpers
- rewrite GUI to create tween videos using FLF2V
- document the new workflow and environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686946f14a288326b9e80baf53ca5645