### PR TITLE
Add FLF2V tween video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ visual elements of the surrounding keyframes for smooth continuity. All frames
 are saved in `./tween_output/frames/` and the final animation will be written
 to `./tween_output/tween.gif`.
 
+If the Wan2.1 FLF2V model is available (set `WAN2_DIR` and `FLF2V_MODEL_DIR` in
+your environment), the tool also creates an `./tween_output/tween.mp4` showing
+the same transition rendered with FLF2V.
+
 For advanced use, `generate_dalle_images` now accepts a `start_index` parameter
 to control the numbering of output frames when generating multiple tween
 segments. This prevents files from being overwritten.

--- a/dalle_tween.py
+++ b/dalle_tween.py
@@ -189,3 +189,57 @@ def combine_images_to_gif(image_paths: List[str], gif_path: str, duration: float
 
     logger.info("Saved animated GIF to %s", gif_path)
     return os.path.abspath(gif_path)
+
+
+def generate_flf2v_tween(
+    start_frame: str,
+    end_frame: str,
+    output_path: str,
+    wan2_dir: str,
+    flf2v_model_dir: str,
+    frame_num: int = 16,
+) -> str:
+    """Generate a short video between two frames using Wan2.1 FLF2V."""
+
+    from pipeline import run_command
+
+    cmd = [
+        "python",
+        "generate.py",
+        "--task",
+        "flf2v-14B",
+        "--size",
+        "1280*720",
+        "--ckpt_dir",
+        flf2v_model_dir,
+        "--first_frame",
+        start_frame,
+        "--last_frame",
+        end_frame,
+        "--frame_num",
+        str(frame_num),
+        "--prompt",
+        "",
+        "--save_file",
+        output_path,
+        "--sample_guide_scale",
+        "5.0",
+        "--sample_steps",
+        "40",
+        "--sample_shift",
+        "5.0",
+    ]
+
+    run_command(cmd, cwd=wan2_dir)
+    return os.path.abspath(output_path)
+
+
+def combine_videos(video_paths: List[str], out_file: str) -> str:
+    """Stitch multiple videos into a single MP4."""
+
+    from pipeline import stitch_video_segments
+
+    stitched = stitch_video_segments(video_paths, out_file)
+    if stitched is None:
+        raise RuntimeError("Failed to stitch tween videos")
+    return stitched

--- a/dalle_tween_gui.py
+++ b/dalle_tween_gui.py
@@ -37,6 +37,8 @@ from dalle_tween import (
     generate_dalle_prompts,
     generate_dalle_images,
     combine_images_to_gif,
+    generate_flf2v_tween,
+    combine_videos,
 )
 
 
@@ -151,6 +153,24 @@ class TweenApp:
             gif_path = os.path.join(out_dir, "tween.gif")
             combine_images_to_gif(all_images, gif_path)
             self.log_message(f"GIF saved to {gif_path}", color=Colors.GREEN)
+
+            wan2_dir = os.environ.get("WAN2_DIR")
+            flf2v_model_dir = os.environ.get("FLF2V_MODEL_DIR")
+            if wan2_dir and flf2v_model_dir:
+                seg1 = os.path.join(out_dir, "segment_01.mp4")
+                seg2 = os.path.join(out_dir, "segment_02.mp4")
+                self.log_message("Generating FLF2V video start->middle...")
+                generate_flf2v_tween(start_frame, middle_frame, seg1, wan2_dir, flf2v_model_dir)
+                self.log_message("Generating FLF2V video middle->end...")
+                generate_flf2v_tween(middle_frame, end_frame, seg2, wan2_dir, flf2v_model_dir)
+                final_mp4 = os.path.join(out_dir, "tween.mp4")
+                combine_videos([seg1, seg2], final_mp4)
+                self.log_message(f"Video saved to {final_mp4}", color=Colors.GREEN)
+            else:
+                self.log_message(
+                    "WAN2_DIR and FLF2V_MODEL_DIR must be set to generate video",
+                    color=Colors.YELLOW,
+                )
         except Exception as exc:
             self.log_message(f"Error: {exc}", color=Colors.RED)
             messagebox.showerror("Generation Failed", str(exc))

--- a/pipeline_config.yaml.sample
+++ b/pipeline_config.yaml.sample
@@ -28,8 +28,9 @@ generation_mode: "chaining"  # Options: "keyframe" or "chaining"
 # ============================================================================
 
 # Model paths for Wan2.1
-wan2_dir: ./Wan2.1                              # Path to Wan2.1 framework code
-flf2v_model_dir: ./models/Wan2.1-FLF2V-14B-720P # Path to the FLF2V model weights (for keyframe mode)
+# Environment variables can be used to override these values
+wan2_dir: ${WAN2_DIR}                           # Path to Wan2.1 framework code
+flf2v_model_dir: ${FLF2V_MODEL_DIR}             # Path to the FLF2V model weights (for keyframe mode)
 i2v_model_dir: ./models/Wan2.1-I2V-14B-720P     # Path to the I2V model weights (for chaining mode)
 
 # GPU settings for local generation


### PR DESCRIPTION
## Summary
- allow DALL·E tween GUI to optionally create Wan2.1 FLF2V videos
- add `generate_flf2v_tween` and `combine_videos` helpers
- document FLF2V tween output
- allow `WAN2_DIR` and `FLF2V_MODEL_DIR` config via environment variables

## Testing
- `python -m py_compile dalle_tween.py dalle_tween_gui.py`

------
https://chatgpt.com/codex/tasks/task_b_68694a3f0508832681c3e4d9670ea05f